### PR TITLE
Fixed versions of Jekyll and grunt-sass.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "http://rubygems.org"
 
-gem 'jekyll'
+gem 'jekyll', '2.5.3'
 gem "jekyll-sitemap"
 gem 'jekyll-multiple-languages-plugin'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "grunt-contrib-watch": "~0.6.1",
         "grunt-critical": "~0.1.2",
         "grunt-jekyll": "~0.4.2",
-        "grunt-sass": "~0.18.1",
+        "grunt-sass": "~1.1.0",
         "grunt-svgmin": "~2.0.1",
         "jit-grunt": "~0.9.1",
         "time-grunt": "~1.1.0"


### PR DESCRIPTION
The project only works with version 2 of Jekyll. The version that is
installed by default is 3 and that breaks the page build, I think the correct version should be in the gemfile. I suggest using version 2.5.3, is the latest today. Grunt-sass
needs to be updated because its version of node-sass fails to compile. I suggest using the version 1.1.0, it compiles and everything seems fine.
