### PR TITLE
Jekyll Multiple Languages plugin version fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "http://rubygems.org"
 
 gem 'jekyll', '2.5.3'
 gem "jekyll-sitemap"
-gem 'jekyll-multiple-languages-plugin'
+gem 'jekyll-multiple-languages-plugin', '1.3.0'


### PR DESCRIPTION
Version 1.4.0 (installed as a newest one) gives the following error:
`/zeppelin-grunt/app/_plugins/jekyll-multiple-languages-plugin.rb:1:in require: cannot load such file -- jekyll/multiple/languages/plugin (LoadError)`
